### PR TITLE
feat(path-lint): add support for linting file names, add lint config schema

### DIFF
--- a/.sasjslint
+++ b/.sasjslint
@@ -1,5 +1,6 @@
 {
     "noTrailingSpaces": true,
     "noEncodedPasswords": true,
-    "hasDoxygenHeader": true
+    "hasDoxygenHeader": true,
+    "noSpacesInFileNames": true
 }

--- a/sasjslint-schema.json
+++ b/sasjslint-schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/sasjs/lint/blob/main/sasjslint-schema.json",
+  "type": "object",
+  "title": "SASjs Lint Config File",
+  "description": "The SASjs Lint Config file provides the settings for customising SAS code style in your project.",
+  "default": {
+    "noTrailingSpaces": true,
+    "noEncodedPasswords": true,
+    "hasDoxygenHeader": true,
+    "noSpacesInFileNames": true
+  },
+  "examples": [
+    {
+      "noTrailingSpaces": true,
+      "noEncodedPasswords": true,
+      "hasDoxygenHeader": true,
+      "noSpacesInFileNames": true
+    }
+  ],
+  "properties": {
+    "noTrailingSpaces": {
+      "$id": "#/properties/noTrailingSpaces",
+      "type": "boolean",
+      "title": "noTrailingSpaces",
+      "description": "Enforces no trailing spaces in lines of SAS code. Shows a warning when they are present.",
+      "default": "true",
+      "examples": ["true", "false"]
+    },
+    "noEncodedPasswords": {
+      "$id": "#/properties/noEncodedPasswords",
+      "type": "boolean",
+      "title": "noEncodedPasswords",
+      "description": "Enforces no encoded passwords such as {SAS001} or {SASENC} in lines of SAS code. Shows an error when they are present.",
+      "default": "true",
+      "examples": ["true", "false"]
+    },
+    "hasDoxygenHeader": {
+      "$id": "#/properties/hasDoxygenHeader",
+      "type": "boolean",
+      "title": "hasDoxygenHeader",
+      "description": "Enforces the presence of a Doxygen header in the form of a comment block at the start of each SAS file. Shows a warning when one is absent.",
+      "default": "true",
+      "examples": ["true", "false"]
+    },
+    "noSpacesInFileNames": {
+      "$id": "#/properties/noSpacesInFileNames",
+      "type": "boolean",
+      "title": "noSpacesInFileNames",
+      "description": "Enforces no spaces in file names. Shows a warning when they are present.",
+      "default": "true",
+      "examples": ["true", "false"]
+    }
+  }
+}

--- a/src/example file.sas
+++ b/src/example file.sas
@@ -1,0 +1,17 @@
+  
+  
+ %macro mf_getuniquelibref(prefix=mclib,maxtries=1000);
+   %local x libref;
+   %let x={SAS002};
+   %do x=0 %to &maxtries;
+   %if %sysfunc(libref(&prefix&x)) ne 0 %then %do;
+     %let libref=&prefix&x;
+     %let rc=%sysfunc(libname(&libref,%sysfunc(pathname(work))));
+     %if &rc %then %put %sysfunc(sysmsg());
+     &prefix&x
+     %*put &sysmacroname: Libref &libref assigned as WORK and returned;
+     %return;
+   %end;
+   %end;
+   %put unable to find available libref in range &prefix.0-&maxtries;
+ %mend;

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,4 +1,4 @@
-import { lint } from './lint'
+import { lintText } from './lint'
 
 /**
  * Example which tests a piece of text with all known violations.
@@ -46,4 +46,4 @@ const text = `/**
  %mend;
 `
 
-lint(text).then((diagnostics) => console.table(diagnostics))
+lintText(text).then((diagnostics) => console.table(diagnostics))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { lint } from './lint'
+export { lintText, lintFile } from './lint'
 export * from './types'

--- a/src/lint.spec.ts
+++ b/src/lint.spec.ts
@@ -1,14 +1,15 @@
-import { lint, splitText } from './lint'
+import { lintFile, lintText, splitText } from './lint'
 import { Severity } from './types/Severity'
+import path from 'path'
 
-describe('lint', () => {
+describe('lintText', () => {
   it('should identify trailing spaces', async () => {
     const text = `/**
       @file
     **/
     %put 'hello'; 
         %put 'world';  `
-    const results = await lint(text)
+    const results = await lintText(text)
 
     expect(results.length).toEqual(2)
     expect(results[0]).toEqual({
@@ -32,7 +33,7 @@ describe('lint', () => {
       @file
     **/
     %put '{SAS001}';`
-    const results = await lint(text)
+    const results = await lintText(text)
 
     expect(results.length).toEqual(1)
     expect(results[0]).toEqual({
@@ -46,7 +47,7 @@ describe('lint', () => {
 
   it('should identify missing doxygen header', async () => {
     const text = `%put 'hello';`
-    const results = await lint(text)
+    const results = await lintText(text)
 
     expect(results.length).toEqual(1)
     expect(results[0]).toEqual({
@@ -62,9 +63,52 @@ describe('lint', () => {
     const text = `/**
       @file
     **/`
-    const results = await lint(text)
+    const results = await lintText(text)
 
     expect(results.length).toEqual(0)
+  })
+})
+
+describe('lintFile', () => {
+  it('should identify lint issues in a given file', async () => {
+    const results = await lintFile(path.join(__dirname, 'example file.sas'))
+
+    expect(results.length).toEqual(5)
+    expect(results).toContainEqual({
+      message: 'Line contains trailing spaces',
+      lineNumber: 1,
+      startColumnNumber: 1,
+      endColumnNumber: 2,
+      severity: Severity.Warning
+    })
+    expect(results).toContainEqual({
+      message: 'Line contains trailing spaces',
+      lineNumber: 2,
+      startColumnNumber: 1,
+      endColumnNumber: 2,
+      severity: Severity.Warning
+    })
+    expect(results).toContainEqual({
+      message: 'File name contains spaces',
+      lineNumber: 1,
+      startColumnNumber: 1,
+      endColumnNumber: 1,
+      severity: Severity.Warning
+    })
+    expect(results).toContainEqual({
+      message: 'File missing Doxygen header',
+      lineNumber: 1,
+      startColumnNumber: 1,
+      endColumnNumber: 1,
+      severity: Severity.Warning
+    })
+    expect(results).toContainEqual({
+      message: 'Line contains encoded password',
+      lineNumber: 5,
+      startColumnNumber: 11,
+      endColumnNumber: 19,
+      severity: Severity.Error
+    })
   })
 })
 

--- a/src/rules/noSpacesInFileNames.spec.ts
+++ b/src/rules/noSpacesInFileNames.spec.ts
@@ -1,0 +1,27 @@
+import { Severity } from '../types/Severity'
+import { noSpacesInFileNames } from './noSpacesInFileNames'
+
+describe('noSpacesInFileNames', () => {
+  it('should return an empty array when the file name has no spaces', () => {
+    const filePath = '/code/sas/my_sas_file.sas'
+    expect(noSpacesInFileNames.test(filePath)).toEqual([])
+  })
+
+  it('should return an empty array when the file name has no spaces, even if the containing folder has spaces', () => {
+    const filePath = '/code/sas projects/my_sas_file.sas'
+    expect(noSpacesInFileNames.test(filePath)).toEqual([])
+  })
+
+  it('should return an array with a single diagnostic when the file name has spaces', () => {
+    const filePath = '/code/sas/my sas file.sas'
+    expect(noSpacesInFileNames.test(filePath)).toEqual([
+      {
+        message: 'File name contains spaces',
+        lineNumber: 1,
+        startColumnNumber: 1,
+        endColumnNumber: 1,
+        severity: Severity.Warning
+      }
+    ])
+  })
+})

--- a/src/rules/noSpacesInFileNames.ts
+++ b/src/rules/noSpacesInFileNames.ts
@@ -1,0 +1,34 @@
+import { PathLintRule } from '../types/LintRule'
+import { LintRuleType } from '../types/LintRuleType'
+import path from 'path'
+import { Severity } from '../types/Severity'
+
+const name = 'noSpacesInFileNames'
+const description = 'Enforce the absence of spaces within file names.'
+const message = 'File name contains spaces'
+const test = (value: string) => {
+  const fileName = path.basename(value)
+  if (fileName.includes(' ')) {
+    return [
+      {
+        message,
+        lineNumber: 1,
+        startColumnNumber: 1,
+        endColumnNumber: 1,
+        severity: Severity.Warning
+      }
+    ]
+  }
+  return []
+}
+
+/**
+ * Lint rule that checks for the absence of spaces in a given file name.
+ */
+export const noSpacesInFileNames: PathLintRule = {
+  type: LintRuleType.Path,
+  name,
+  description,
+  message,
+  test
+}

--- a/src/types/LintConfig.ts
+++ b/src/types/LintConfig.ts
@@ -1,7 +1,8 @@
 import { hasDoxygenHeader } from '../rules/hasDoxygenHeader'
 import { noEncodedPasswords } from '../rules/noEncodedPasswords'
+import { noSpacesInFileNames } from '../rules/noSpacesInFileNames'
 import { noTrailingSpaces } from '../rules/noTrailingSpaces'
-import { FileLintRule, LineLintRule } from './LintRule'
+import { FileLintRule, LineLintRule, PathLintRule } from './LintRule'
 
 /**
  * LintConfig is the logical representation of the .sasjslint file.
@@ -13,6 +14,7 @@ import { FileLintRule, LineLintRule } from './LintRule'
 export class LintConfig {
   readonly lineLintRules: LineLintRule[] = []
   readonly fileLintRules: FileLintRule[] = []
+  readonly pathLintRules: PathLintRule[] = []
 
   constructor(json?: any) {
     if (json?.noTrailingSpaces) {
@@ -25,6 +27,10 @@ export class LintConfig {
 
     if (json?.hasDoxygenHeader) {
       this.fileLintRules.push(hasDoxygenHeader)
+    }
+
+    if (json?.noSpacesInFileNames) {
+      this.pathLintRules.push(noSpacesInFileNames)
     }
   }
 }

--- a/src/types/LintRule.ts
+++ b/src/types/LintRule.ts
@@ -10,7 +10,6 @@ export interface LintRule {
   name: string
   description: string
   message: string
-  test: (value: string, lineNumber: number) => Diagnostic[]
 }
 
 /**
@@ -18,6 +17,7 @@ export interface LintRule {
  */
 export interface LineLintRule extends LintRule {
   type: LintRuleType.Line
+  test: (value: string, lineNumber: number) => Diagnostic[]
 }
 
 /**
@@ -25,5 +25,13 @@ export interface LineLintRule extends LintRule {
  */
 export interface FileLintRule extends LintRule {
   type: LintRuleType.File
+  test: (value: string) => Diagnostic[]
+}
+
+/**
+ * A PathLintRule is run once per file.
+ */
+export interface PathLintRule extends LintRule {
+  type: LintRuleType.Path
   test: (value: string) => Diagnostic[]
 }

--- a/src/types/LintRuleType.ts
+++ b/src/types/LintRuleType.ts
@@ -4,5 +4,6 @@
  */
 export enum LintRuleType {
   Line,
-  File
+  File,
+  Path
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   ],
   "exclude": [
       "node_modules",
-      "**/*.spec.ts"
+      "**/*.spec.ts",
+      "**/example.ts"
   ]
 }


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/lint/issues/7.
Fixes https://github.com/sasjs/lint/issues/8

## Intent

Add file path linting, add schema for .sasjslint file.

## Implementation

* Added `LintRuleType.Path`.
* Split implementation into `lintText` which takes a piece of text, and `lintFile` which takes a file path.
* Added schema for .sasjslint file.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
