### PR TITLE
fix(has-doxygen-header): fix logic to handle files with comment blocks

### DIFF
--- a/src/rules/hasDoxygenHeader.spec.ts
+++ b/src/rules/hasDoxygenHeader.spec.ts
@@ -34,6 +34,27 @@ describe('hasDoxygenHeader', () => {
     ])
   })
 
+  it('should return an array with a single diagnostic when the file has comment blocks but no header', () => {
+    const content = `
+ %macro mf_getuniquelibref(prefix=mclib,maxtries=1000);
+   %local x libref;
+   %let x={SAS002};
+  /** Comment Line 1
+   * Comment Line 2
+   */
+   %do x=0 %to &maxtries;`
+
+    expect(hasDoxygenHeader.test(content)).toEqual([
+      {
+        message: 'File missing Doxygen header',
+        lineNumber: 1,
+        startColumnNumber: 1,
+        endColumnNumber: 1,
+        severity: Severity.Warning
+      }
+    ])
+  })
+
   it('should return an array with a single diagnostic when the file is undefined', () => {
     const content = undefined
 

--- a/src/rules/hasDoxygenHeader.ts
+++ b/src/rules/hasDoxygenHeader.ts
@@ -8,7 +8,7 @@ const description =
 const message = 'File missing Doxygen header'
 const test = (value: string) => {
   try {
-    const hasFileHeader = value.split('/**')[0] !== value
+    const hasFileHeader = value.trimStart().startsWith('/*')
     if (hasFileHeader) return []
     return [
       {


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/lint/issues/14

## Intent

Fix false negative with `hasDoxygenHeader` rule.

## Implementation

* Check if file starts with a comment block.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
