### PR TITLE
feat(*): group folder and project diagnostics by file path

### DIFF
--- a/src/lint/lintFolder.spec.ts
+++ b/src/lint/lintFolder.spec.ts
@@ -6,57 +6,61 @@ describe('lintFolder', () => {
   it('should identify lint issues in a given folder', async () => {
     const results = await lintFolder(path.join(__dirname, '..'))
 
-    expect(results.length).toEqual(8)
-    expect(results).toContainEqual({
+    expect(results.size).toEqual(1)
+    const diagnostics = results.get(
+      path.join(__dirname, '..', 'Example File.sas')
+    )!
+    expect(diagnostics.length).toEqual(8)
+    expect(diagnostics).toContainEqual({
       message: 'Line contains trailing spaces',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 2,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line contains trailing spaces',
       lineNumber: 2,
       startColumnNumber: 1,
       endColumnNumber: 2,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'File name contains spaces',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'File name contains uppercase characters',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'File missing Doxygen header',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line contains encoded password',
       lineNumber: 5,
       startColumnNumber: 10,
       endColumnNumber: 18,
       severity: Severity.Error
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line is indented with a tab',
       lineNumber: 7,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line has incorrect indentation - 3 spaces',
       lineNumber: 6,
       startColumnNumber: 1,

--- a/src/lint/lintProject.spec.ts
+++ b/src/lint/lintProject.spec.ts
@@ -1,67 +1,86 @@
 import { lintProject } from './lintProject'
 import { Severity } from '../types/Severity'
+import * as utils from '../utils'
 import path from 'path'
+jest.mock('../utils')
 
 describe('lintProject', () => {
   it('should identify lint issues in a given project', async () => {
+    jest
+      .spyOn(utils, 'getProjectRoot')
+      .mockImplementationOnce(() => Promise.resolve(path.join(__dirname, '..')))
     const results = await lintProject()
 
-    expect(results.length).toEqual(8)
-    expect(results).toContainEqual({
+    expect(results.size).toEqual(1)
+    const diagnostics = results.get(
+      path.join(__dirname, '..', 'Example File.sas')
+    )!
+    expect(diagnostics.length).toEqual(8)
+    expect(diagnostics).toContainEqual({
       message: 'Line contains trailing spaces',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 2,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line contains trailing spaces',
       lineNumber: 2,
       startColumnNumber: 1,
       endColumnNumber: 2,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'File name contains spaces',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'File name contains uppercase characters',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'File missing Doxygen header',
       lineNumber: 1,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line contains encoded password',
       lineNumber: 5,
       startColumnNumber: 10,
       endColumnNumber: 18,
       severity: Severity.Error
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line is indented with a tab',
       lineNumber: 7,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-    expect(results).toContainEqual({
+    expect(diagnostics).toContainEqual({
       message: 'Line has incorrect indentation - 3 spaces',
       lineNumber: 6,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
+  })
+
+  it('should throw an error when a project root is not found', async () => {
+    jest
+      .spyOn(utils, 'getProjectRoot')
+      .mockImplementationOnce(() => Promise.resolve(''))
+
+    await expect(lintProject()).rejects.toThrowError(
+      'SASjs Project Root was not found.'
+    )
   })
 })

--- a/src/lint/lintProject.ts
+++ b/src/lint/lintProject.ts
@@ -3,7 +3,7 @@ import { lintFolder } from './lintFolder'
 
 /**
  * Analyses and produces a set of diagnostics for the current project.
- * @returns {Diagnostic[]} array of diagnostic objects, each containing a warning, line number and column number.
+ * @returns {Promise<Map<string, Diagnostic[]>>} Resolves with a map with array of diagnostic objects, each containing a warning, line number and column number, and grouped by file path.
  */
 export const lintProject = async () => {
   const projectRoot =

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       ],
       "target": "es5",
       "module": "commonjs",
+      "downlevelIteration": true,
       "moduleResolution": "node",
       "esModuleInterop": true,
       "declaration": true,


### PR DESCRIPTION
## Issue

#1 

## Intent

Group diagnostics from folder and project linting by file path.

## Implementation

* Return maps with file paths as keys when `lintProject` or `lintFolder` are called.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
