### PR TITLE
fix(*): improve new rules, update schema and comments

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,5 +16,6 @@ What code changes have been made to achieve the intent.
 - [ ] Any new functionality has been unit tested.
 - [ ] All unit tests are passing (`npm test`).
 - [ ] All CI checks are green.
+- [ ] sasjslint-schema.json is updated with any new / changed functionality
 - [ ] JSDoc comments have been added or updated.
 - [ ] Reviewer is assigned.

--- a/sasjslint-schema.json
+++ b/sasjslint-schema.json
@@ -12,7 +12,10 @@
     "lowerCaseFileNames": true,
     "maxLineLength": 80,
     "noTabIndentation": true,
-    "indentationMultiple": 2
+    "indentationMultiple": 2,
+    "hasMacroNameInMend": false,
+    "noNestedMacros": true,
+    "hasMacroParentheses": true
   },
   "examples": [
     {
@@ -23,7 +26,10 @@
       "lowerCaseFileNames": true,
       "maxLineLength": 80,
       "noTabIndentation": true,
-      "indentationMultiple": 4
+      "indentationMultiple": 4,
+      "hasMacroNameInMend": true,
+      "noNestedMacros": true,
+      "hasMacroParentheses": true
     }
   ],
   "properties": {
@@ -90,6 +96,30 @@
       "description": "Enforces a configurable multiple for the number of spaces for indentation. Shows a warning for lines that are not indented by a multiple of this number.",
       "default": 2,
       "examples": [2, 3, 4]
+    },
+    "hasMacroNameInMend": {
+      "$id": "#/properties/hasMacroNameInMend",
+      "type": "boolean",
+      "title": "hasMacroNameInMend",
+      "description": "Enforces the presence of macro names in %mend statements. Shows a warning for %mend statements with missing or mismatched macro names.",
+      "default": false,
+      "examples": [true, false]
+    },
+    "noNestedMacros": {
+      "$id": "#/properties/noNestedMacros",
+      "type": "boolean",
+      "title": "noNestedMacros",
+      "description": "Enforces the absence of nested macro definitions. Shows a warning for each nested macro definition.",
+      "default": true,
+      "examples": [true, false]
+    },
+    "hasMacroParentheses": {
+      "$id": "#/properties/hasMacroParentheses",
+      "type": "boolean",
+      "title": "hasMacroParentheses",
+      "description": "Enforces the presence of parantheses in macro definitions. Shows a warning for each macro defined without parantheses.",
+      "default": true,
+      "examples": [true, false]
     }
   }
 }

--- a/sasjslint-schema.json
+++ b/sasjslint-schema.json
@@ -5,17 +5,17 @@
   "title": "SASjs Lint Config File",
   "description": "The SASjs Lint Config file provides the settings for customising SAS code style in your project.",
   "default": {
-    "noTrailingSpaces": true,
     "noEncodedPasswords": true,
     "hasDoxygenHeader": true,
-    "noSpacesInFileNames": true,
+    "hasMacroNameInMend": false,
+    "hasMacroParentheses": true,
+    "indentationMultiple": 2,
     "lowerCaseFileNames": true,
     "maxLineLength": 80,
-    "noTabIndentation": true,
-    "indentationMultiple": 2,
-    "hasMacroNameInMend": false,
     "noNestedMacros": true,
-    "hasMacroParentheses": true
+    "noSpacesInFileNames": true,
+    "noTabIndentation": true,
+    "noTrailingSpaces": true
   },
   "examples": [
     {
@@ -33,14 +33,6 @@
     }
   ],
   "properties": {
-    "noTrailingSpaces": {
-      "$id": "#/properties/noTrailingSpaces",
-      "type": "boolean",
-      "title": "noTrailingSpaces",
-      "description": "Enforces no trailing spaces in lines of SAS code. Shows a warning when they are present.",
-      "default": true,
-      "examples": [true, false]
-    },
     "noEncodedPasswords": {
       "$id": "#/properties/noEncodedPasswords",
       "type": "boolean",
@@ -57,13 +49,29 @@
       "default": true,
       "examples": [true, false]
     },
-    "noSpacesInFileNames": {
-      "$id": "#/properties/noSpacesInFileNames",
+    "hasMacroNameInMend": {
+      "$id": "#/properties/hasMacroNameInMend",
       "type": "boolean",
-      "title": "noSpacesInFileNames",
-      "description": "Enforces no spaces in file names. Shows a warning when they are present.",
+      "title": "hasMacroNameInMend",
+      "description": "Enforces the presence of macro names in %mend statements. Shows a warning for %mend statements with missing or mismatched macro names.",
+      "default": false,
+      "examples": [true, false]
+    },
+    "hasMacroParentheses": {
+      "$id": "#/properties/hasMacroParentheses",
+      "type": "boolean",
+      "title": "hasMacroParentheses",
+      "description": "Enforces the presence of parentheses in macro definitions. Shows a warning for each macro defined without parentheses, or with spaces between the macro name and the opening parenthesis.",
       "default": true,
       "examples": [true, false]
+    },
+    "indentationMultiple": {
+      "$id": "#/properties/indentationMultiple",
+      "type": "number",
+      "title": "indentationMultiple",
+      "description": "Enforces a configurable multiple for the number of spaces for indentation. Shows a warning for lines that are not indented by a multiple of this number.",
+      "default": 2,
+      "examples": [2, 3, 4]
     },
     "lowerCaseFileNames": {
       "$id": "#/properties/lowerCaseFileNames",
@@ -81,30 +89,6 @@
       "default": 80,
       "examples": [60, 80, 120]
     },
-    "noTabIndentation": {
-      "$id": "#/properties/noTabIndentation",
-      "type": "boolean",
-      "title": "noTabIndentation",
-      "description": "Enforces no indentation using tabs. Shows a warning when a line starts with a tab.",
-      "default": true,
-      "examples": [true, false]
-    },
-    "indentationMultiple": {
-      "$id": "#/properties/indentationMultiple",
-      "type": "number",
-      "title": "indentationMultiple",
-      "description": "Enforces a configurable multiple for the number of spaces for indentation. Shows a warning for lines that are not indented by a multiple of this number.",
-      "default": 2,
-      "examples": [2, 3, 4]
-    },
-    "hasMacroNameInMend": {
-      "$id": "#/properties/hasMacroNameInMend",
-      "type": "boolean",
-      "title": "hasMacroNameInMend",
-      "description": "Enforces the presence of macro names in %mend statements. Shows a warning for %mend statements with missing or mismatched macro names.",
-      "default": false,
-      "examples": [true, false]
-    },
     "noNestedMacros": {
       "$id": "#/properties/noNestedMacros",
       "type": "boolean",
@@ -113,11 +97,27 @@
       "default": true,
       "examples": [true, false]
     },
-    "hasMacroParentheses": {
-      "$id": "#/properties/hasMacroParentheses",
+    "noSpacesInFileNames": {
+      "$id": "#/properties/noSpacesInFileNames",
       "type": "boolean",
-      "title": "hasMacroParentheses",
-      "description": "Enforces the presence of parantheses in macro definitions. Shows a warning for each macro defined without parantheses.",
+      "title": "noSpacesInFileNames",
+      "description": "Enforces no spaces in file names. Shows a warning when they are present.",
+      "default": true,
+      "examples": [true, false]
+    },
+    "noTabIndentation": {
+      "$id": "#/properties/noTabIndentation",
+      "type": "boolean",
+      "title": "noTabIndentation",
+      "description": "Enforces no indentation using tabs. Shows a warning when a line starts with a tab.",
+      "default": true,
+      "examples": [true, false]
+    },
+    "noTrailingSpaces": {
+      "$id": "#/properties/noTrailingSpaces",
+      "type": "boolean",
+      "title": "noTrailingSpaces",
+      "description": "Enforces no trailing spaces in lines of SAS code. Shows a warning when they are present.",
       "default": true,
       "examples": [true, false]
     }

--- a/src/rules/hasMacroNameInMend.spec.ts
+++ b/src/rules/hasMacroNameInMend.spec.ts
@@ -28,10 +28,48 @@ describe('hasMacroNameInMend', () => {
 
     expect(hasMacroNameInMend.test(content)).toEqual([
       {
-        message: '%mend missing macro name',
+        message: '%mend statement is missing macro name',
         lineNumber: 4,
         startColumnNumber: 3,
         endColumnNumber: 9,
+        severity: Severity.Warning
+      }
+    ])
+  })
+
+  it('should return an array with a single diagnostic when a macro is missing an %mend statement', () => {
+    const content = `%macro somemacro;
+    %put &sysmacroname;`
+
+    expect(hasMacroNameInMend.test(content)).toEqual([
+      {
+        message: 'Missing %mend statement for macro - somemacro',
+        lineNumber: 1,
+        startColumnNumber: 1,
+        endColumnNumber: 1,
+        severity: Severity.Warning
+      }
+    ])
+  })
+
+  it('should return an array with a diagnostic for each macro missing an %mend statement', () => {
+    const content = `%macro somemacro;
+    %put &sysmacroname;
+    %macro othermacro`
+
+    expect(hasMacroNameInMend.test(content)).toEqual([
+      {
+        message: 'Missing %mend statement for macro - somemacro',
+        lineNumber: 1,
+        startColumnNumber: 1,
+        endColumnNumber: 1,
+        severity: Severity.Warning
+      },
+      {
+        message: 'Missing %mend statement for macro - othermacro',
+        lineNumber: 3,
+        startColumnNumber: 1,
+        endColumnNumber: 1,
         severity: Severity.Warning
       }
     ])
@@ -45,7 +83,7 @@ describe('hasMacroNameInMend', () => {
 
     expect(hasMacroNameInMend.test(content)).toEqual([
       {
-        message: 'mismatch macro name in %mend statement',
+        message: '%mend statement has mismatched macro name',
         lineNumber: 4,
         startColumnNumber: 9,
         endColumnNumber: 24,
@@ -88,7 +126,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend missing macro name',
+          message: '%mend statement is missing macro name',
           lineNumber: 6,
           startColumnNumber: 5,
           endColumnNumber: 11,
@@ -110,7 +148,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend missing macro name',
+          message: '%mend statement is missing macro name',
           lineNumber: 9,
           startColumnNumber: 3,
           endColumnNumber: 9,
@@ -132,14 +170,14 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend missing macro name',
+          message: '%mend statement is missing macro name',
           lineNumber: 6,
           startColumnNumber: 5,
           endColumnNumber: 11,
           severity: Severity.Warning
         },
         {
-          message: '%mend missing macro name',
+          message: '%mend statement is missing macro name',
           lineNumber: 9,
           startColumnNumber: 3,
           endColumnNumber: 9,
@@ -197,7 +235,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend missing macro name',
+          message: '%mend statement is missing macro name',
           lineNumber: 29,
           startColumnNumber: 5,
           endColumnNumber: 11,
@@ -216,7 +254,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: 'mismatch macro name in %mend statement',
+          message: '%mend statement has mismatched macro name',
           lineNumber: 6,
           startColumnNumber: 14,
           endColumnNumber: 29,
@@ -233,7 +271,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend missing macro name',
+          message: '%mend statement is missing macro name',
           lineNumber: 4,
           startColumnNumber: 5,
           endColumnNumber: 11,

--- a/src/rules/hasMacroNameInMend.spec.ts
+++ b/src/rules/hasMacroNameInMend.spec.ts
@@ -92,6 +92,24 @@ describe('hasMacroNameInMend', () => {
     ])
   })
 
+  it('should return an array with a single diagnostic when extra %mend statement is present', () => {
+    const content = `
+  %macro somemacro;
+    %put &sysmacroname;
+  %mend somemacro;
+  %mend something;`
+
+    expect(hasMacroNameInMend.test(content)).toEqual([
+      {
+        message: '%mend statement is redundant',
+        lineNumber: 5,
+        startColumnNumber: 3,
+        endColumnNumber: 18,
+        severity: Severity.Warning
+      }
+    ])
+  })
+
   it('should return an empty array when the file is undefined', () => {
     const content = undefined
 

--- a/src/rules/hasMacroNameInMend.spec.ts
+++ b/src/rules/hasMacroNameInMend.spec.ts
@@ -28,7 +28,7 @@ describe('hasMacroNameInMend', () => {
 
     expect(hasMacroNameInMend.test(content)).toEqual([
       {
-        message: '%mend statement is missing macro name',
+        message: '%mend statement is missing macro name - somemacro',
         lineNumber: 4,
         startColumnNumber: 3,
         endColumnNumber: 9,
@@ -83,7 +83,7 @@ describe('hasMacroNameInMend', () => {
 
     expect(hasMacroNameInMend.test(content)).toEqual([
       {
-        message: '%mend statement has mismatched macro name',
+        message: `%mend statement has mismatched macro name, it should be 'somemacro'`,
         lineNumber: 4,
         startColumnNumber: 9,
         endColumnNumber: 24,
@@ -126,7 +126,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend statement is missing macro name',
+          message: '%mend statement is missing macro name - inner',
           lineNumber: 6,
           startColumnNumber: 5,
           endColumnNumber: 11,
@@ -148,7 +148,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend statement is missing macro name',
+          message: '%mend statement is missing macro name - outer',
           lineNumber: 9,
           startColumnNumber: 3,
           endColumnNumber: 9,
@@ -170,14 +170,14 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend statement is missing macro name',
+          message: '%mend statement is missing macro name - inner',
           lineNumber: 6,
           startColumnNumber: 5,
           endColumnNumber: 11,
           severity: Severity.Warning
         },
         {
-          message: '%mend statement is missing macro name',
+          message: '%mend statement is missing macro name - outer',
           lineNumber: 9,
           startColumnNumber: 3,
           endColumnNumber: 9,
@@ -235,7 +235,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend statement is missing macro name',
+          message: '%mend statement is missing macro name - examplemacro',
           lineNumber: 29,
           startColumnNumber: 5,
           endColumnNumber: 11,
@@ -254,7 +254,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend statement has mismatched macro name',
+          message: `%mend statement has mismatched macro name, it should be 'somemacro'`,
           lineNumber: 6,
           startColumnNumber: 14,
           endColumnNumber: 29,
@@ -271,7 +271,7 @@ describe('hasMacroNameInMend', () => {
 
       expect(hasMacroNameInMend.test(content)).toEqual([
         {
-          message: '%mend statement is missing macro name',
+          message: '%mend statement is missing macro name - somemacro',
           lineNumber: 4,
           startColumnNumber: 5,
           endColumnNumber: 11,

--- a/src/rules/hasMacroNameInMend.ts
+++ b/src/rules/hasMacroNameInMend.ts
@@ -36,17 +36,27 @@ const test = (value: string) => {
           .slice(7, trimmedStatement.length)
           .trim()
           .split('(')[0]
-        declaredMacros.push({
-          name: macroName,
-          lineNumber: lineIndex + 1
-        })
+        if (macroName)
+          declaredMacros.push({
+            name: macroName,
+            lineNumber: lineIndex + 1
+          })
       } else if (trimmedStatement.startsWith('%mend')) {
         const declaredMacro = declaredMacros.pop()
         const macroName = trimmedStatement
           .split(' ')
           .filter((s: string) => !!s)[1]
 
-        if (!macroName) {
+        if (!declaredMacro) {
+          diagnostics.push({
+            message: `%mend statement is redundant`,
+            lineNumber: lineIndex + 1,
+            startColumnNumber: getColumnNumber(line, '%mend'),
+            endColumnNumber:
+              getColumnNumber(line, '%mend') + trimmedStatement.length,
+            severity: Severity.Warning
+          })
+        } else if (!macroName) {
           diagnostics.push({
             message: `%mend statement is missing macro name - ${
               declaredMacro!.name

--- a/src/rules/hasMacroNameInMend.ts
+++ b/src/rules/hasMacroNameInMend.ts
@@ -13,51 +13,64 @@ const message = '%mend statement has missing or incorrect macro name'
 const test = (value: string) => {
   const diagnostics: Diagnostic[] = []
 
-  const statements: string[] = value ? value.split(';') : []
+  const lines: string[] = value ? value.split('\n') : []
 
   const declaredMacros: { name: string; lineNumber: number }[] = []
   let isCommentStarted = false
-  statements.forEach((statement, index) => {
-    const { statement: trimmedStatement, commentStarted } = trimComments(
-      statement,
+  lines.forEach((line, index) => {
+    const { statement: trimmedLine, commentStarted } = trimComments(
+      line,
       isCommentStarted
     )
     isCommentStarted = commentStarted
+    const statements: string[] = trimmedLine ? trimmedLine.split(';') : []
 
-    if (trimmedStatement.startsWith('%macro ')) {
-      const macroName = trimmedStatement
-        .slice(7, trimmedStatement.length)
-        .trim()
-        .split('(')[0]
-      declaredMacros.push({
-        name: macroName,
-        lineNumber: getLineNumber(statements, index + 1)
-      })
-    } else if (trimmedStatement.startsWith('%mend')) {
-      const declaredMacro = declaredMacros.pop()
-      const macroName = trimmedStatement
-        .split(' ')
-        .filter((s: string) => !!s)[1]
+    statements.forEach((statement) => {
+      const { statement: trimmedStatement, commentStarted } = trimComments(
+        statement,
+        isCommentStarted
+      )
+      isCommentStarted = commentStarted
 
-      if (!macroName) {
-        diagnostics.push({
-          message: '%mend statement is missing macro name',
-          lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColumnNumber(statement, '%mend'),
-          endColumnNumber: getColumnNumber(statement, '%mend') + 6,
-          severity: Severity.Warning
+      if (trimmedStatement.startsWith('%macro ')) {
+        const macroName = trimmedStatement
+          .slice(7, trimmedStatement.length)
+          .trim()
+          .split('(')[0]
+        declaredMacros.push({
+          name: macroName,
+          lineNumber: getLineNumber(lines, index + 1)
         })
-      } else if (macroName !== declaredMacro!.name) {
-        diagnostics.push({
-          message: '%mend statement has mismatched macro name',
-          lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColumnNumber(statement, macroName),
-          endColumnNumber:
-            getColumnNumber(statement, macroName) + macroName.length - 1,
-          severity: Severity.Warning
-        })
+      } else if (trimmedStatement.startsWith('%mend')) {
+        const declaredMacro = declaredMacros.pop()
+        const macroName = trimmedStatement
+          .split(' ')
+          .filter((s: string) => !!s)[1]
+
+        if (!macroName) {
+          diagnostics.push({
+            message: `%mend statement is missing macro name - ${
+              declaredMacro!.name
+            }`,
+            lineNumber: getLineNumber(lines, index + 1),
+            startColumnNumber: getColumnNumber(line, '%mend'),
+            endColumnNumber: getColumnNumber(line, '%mend') + 6,
+            severity: Severity.Warning
+          })
+        } else if (macroName !== declaredMacro!.name) {
+          diagnostics.push({
+            message: `%mend statement has mismatched macro name, it should be '${
+              declaredMacro!.name
+            }'`,
+            lineNumber: getLineNumber(lines, index + 1),
+            startColumnNumber: getColumnNumber(line, macroName),
+            endColumnNumber:
+              getColumnNumber(line, macroName) + macroName.length - 1,
+            severity: Severity.Warning
+          })
+        }
       }
-    }
+    })
   })
 
   declaredMacros.forEach((declaredMacro) => {

--- a/src/rules/hasMacroNameInMend.ts
+++ b/src/rules/hasMacroNameInMend.ts
@@ -4,66 +4,72 @@ import { LintRuleType } from '../types/LintRuleType'
 import { Severity } from '../types/Severity'
 import { trimComments } from '../utils/trimComments'
 import { getLineNumber } from '../utils/getLineNumber'
-import { getColNumber } from '../utils/getColNumber'
+import { getColumnNumber } from '../utils/getColumnNumber'
 
 const name = 'hasMacroNameInMend'
-const description = 'The %mend statement should contain the macro name'
-const message = '$mend statement missing or incorrect'
+const description =
+  'Enforces the presence of the macro name in each %mend statement.'
+const message = '%mend statement has missing or incorrect macro name'
 const test = (value: string) => {
   const diagnostics: Diagnostic[] = []
 
   const statements: string[] = value ? value.split(';') : []
 
-  const stack: string[] = []
-  let trimmedStatement = '',
-    commentStarted = false
+  const declaredMacros: { name: string; lineNumber: number }[] = []
+  let isCommentStarted = false
   statements.forEach((statement, index) => {
-    ;({ statement: trimmedStatement, commentStarted } = trimComments(
+    const { statement: trimmedStatement, commentStarted } = trimComments(
       statement,
-      commentStarted
-    ))
+      isCommentStarted
+    )
+    isCommentStarted = commentStarted
 
     if (trimmedStatement.startsWith('%macro ')) {
       const macroName = trimmedStatement
         .slice(7, trimmedStatement.length)
         .trim()
         .split('(')[0]
-      stack.push(macroName)
+      declaredMacros.push({
+        name: macroName,
+        lineNumber: getLineNumber(statements, index + 1)
+      })
     } else if (trimmedStatement.startsWith('%mend')) {
-      const macroStarted = stack.pop()
+      const declaredMacro = declaredMacros.pop()
       const macroName = trimmedStatement
         .split(' ')
         .filter((s: string) => !!s)[1]
 
       if (!macroName) {
         diagnostics.push({
-          message: '%mend missing macro name',
+          message: '%mend statement is missing macro name',
           lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColNumber(statement, '%mend'),
-          endColumnNumber: getColNumber(statement, '%mend') + 6,
+          startColumnNumber: getColumnNumber(statement, '%mend'),
+          endColumnNumber: getColumnNumber(statement, '%mend') + 6,
           severity: Severity.Warning
         })
-      } else if (macroName !== macroStarted) {
+      } else if (macroName !== declaredMacro!.name) {
         diagnostics.push({
-          message: 'mismatch macro name in %mend statement',
+          message: '%mend statement has mismatched macro name',
           lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColNumber(statement, macroName),
+          startColumnNumber: getColumnNumber(statement, macroName),
           endColumnNumber:
-            getColNumber(statement, macroName) + macroName.length - 1,
+            getColumnNumber(statement, macroName) + macroName.length - 1,
           severity: Severity.Warning
         })
       }
     }
   })
-  if (stack.length) {
+
+  declaredMacros.forEach((declaredMacro) => {
     diagnostics.push({
-      message: 'missing %mend statement for macro(s)',
-      lineNumber: statements.length + 1,
+      message: `Missing %mend statement for macro - ${declaredMacro.name}`,
+      lineNumber: declaredMacro.lineNumber,
       startColumnNumber: 1,
       endColumnNumber: 1,
       severity: Severity.Warning
     })
-  }
+  })
+
   return diagnostics
 }
 

--- a/src/rules/hasMacroNameInMend.ts
+++ b/src/rules/hasMacroNameInMend.ts
@@ -3,7 +3,6 @@ import { FileLintRule } from '../types/LintRule'
 import { LintRuleType } from '../types/LintRuleType'
 import { Severity } from '../types/Severity'
 import { trimComments } from '../utils/trimComments'
-import { getLineNumber } from '../utils/getLineNumber'
 import { getColumnNumber } from '../utils/getColumnNumber'
 
 const name = 'hasMacroNameInMend'
@@ -17,7 +16,7 @@ const test = (value: string) => {
 
   const declaredMacros: { name: string; lineNumber: number }[] = []
   let isCommentStarted = false
-  lines.forEach((line, index) => {
+  lines.forEach((line, lineIndex) => {
     const { statement: trimmedLine, commentStarted } = trimComments(
       line,
       isCommentStarted
@@ -39,7 +38,7 @@ const test = (value: string) => {
           .split('(')[0]
         declaredMacros.push({
           name: macroName,
-          lineNumber: getLineNumber(lines, index + 1)
+          lineNumber: lineIndex + 1
         })
       } else if (trimmedStatement.startsWith('%mend')) {
         const declaredMacro = declaredMacros.pop()
@@ -52,7 +51,7 @@ const test = (value: string) => {
             message: `%mend statement is missing macro name - ${
               declaredMacro!.name
             }`,
-            lineNumber: getLineNumber(lines, index + 1),
+            lineNumber: lineIndex + 1,
             startColumnNumber: getColumnNumber(line, '%mend'),
             endColumnNumber: getColumnNumber(line, '%mend') + 6,
             severity: Severity.Warning
@@ -62,7 +61,7 @@ const test = (value: string) => {
             message: `%mend statement has mismatched macro name, it should be '${
               declaredMacro!.name
             }'`,
-            lineNumber: getLineNumber(lines, index + 1),
+            lineNumber: lineIndex + 1,
             startColumnNumber: getColumnNumber(line, macroName),
             endColumnNumber:
               getColumnNumber(line, macroName) + macroName.length - 1,

--- a/src/rules/hasMacroParentheses.spec.ts
+++ b/src/rules/hasMacroParentheses.spec.ts
@@ -36,7 +36,7 @@ describe('hasMacroParentheses', () => {
 
     expect(hasMacroParentheses.test(content)).toEqual([
       {
-        message: 'Macro definition missing name',
+        message: 'Macro definition contains space(s)',
         lineNumber: 2,
         startColumnNumber: 3,
         endColumnNumber: 12,
@@ -53,10 +53,10 @@ describe('hasMacroParentheses', () => {
 
     expect(hasMacroParentheses.test(content)).toEqual([
       {
-        message: 'Macro definition missing name',
+        message: 'Macro definition contains space(s)',
         lineNumber: 2,
         startColumnNumber: 3,
-        endColumnNumber: 10,
+        endColumnNumber: 9,
         severity: Severity.Warning
       }
     ])

--- a/src/rules/hasMacroParentheses.spec.ts
+++ b/src/rules/hasMacroParentheses.spec.ts
@@ -125,4 +125,18 @@ describe('hasMacroParentheses', () => {
       ])
     })
   })
+
+  it('should return an array with a single diagnostic when a macro definition contains a space', () => {
+    const content = `%macro test ()`
+
+    expect(hasMacroParentheses.test(content)).toEqual([
+      {
+        message: 'Macro definition contains space(s)',
+        lineNumber: 1,
+        startColumnNumber: 8,
+        endColumnNumber: 14,
+        severity: Severity.Warning
+      }
+    ])
+  })
 })

--- a/src/rules/hasMacroParentheses.spec.ts
+++ b/src/rules/hasMacroParentheses.spec.ts
@@ -36,7 +36,7 @@ describe('hasMacroParentheses', () => {
 
     expect(hasMacroParentheses.test(content)).toEqual([
       {
-        message: 'Macro definition contains space(s)',
+        message: 'Macro definition missing name',
         lineNumber: 2,
         startColumnNumber: 3,
         endColumnNumber: 12,
@@ -53,7 +53,7 @@ describe('hasMacroParentheses', () => {
 
     expect(hasMacroParentheses.test(content)).toEqual([
       {
-        message: 'Macro definition contains space(s)',
+        message: 'Macro definition missing name',
         lineNumber: 2,
         startColumnNumber: 3,
         endColumnNumber: 9,

--- a/src/rules/hasMacroParentheses.ts
+++ b/src/rules/hasMacroParentheses.ts
@@ -12,55 +12,64 @@ const message = 'Macro definition missing parentheses'
 const test = (value: string) => {
   const diagnostics: Diagnostic[] = []
 
-  const statements: string[] = value ? value.split(';') : []
-
+  const lines: string[] = value ? value.split('\n') : []
   let isCommentStarted = false
-  statements.forEach((statement, index) => {
-    const { statement: trimmedStatement, commentStarted } = trimComments(
-      statement,
+  lines.forEach((line, index) => {
+    const { statement: trimmedLine, commentStarted } = trimComments(
+      line,
       isCommentStarted
     )
     isCommentStarted = commentStarted
+    const statements: string[] = trimmedLine ? trimmedLine.split(';') : []
 
-    if (trimmedStatement.startsWith('%macro')) {
-      const macroNameDefinition = trimmedStatement
-        .slice(7, trimmedStatement.length)
-        .trim()
+    statements.forEach((statement) => {
+      const { statement: trimmedStatement, commentStarted } = trimComments(
+        statement,
+        isCommentStarted
+      )
+      isCommentStarted = commentStarted
 
-      const macroNameDefinitionParts = macroNameDefinition.split('(')
-      const macroName = macroNameDefinitionParts[0]
+      if (trimmedStatement.startsWith('%macro')) {
+        const macroNameDefinition = trimmedStatement
+          .slice(7, trimmedStatement.length)
+          .trim()
 
-      if (!macroName)
-        diagnostics.push({
-          message: 'Macro definition missing name',
-          lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColumnNumber(statement, '%macro'),
-          endColumnNumber: statement.length,
-          severity: Severity.Warning
-        })
-      else if (macroNameDefinitionParts.length === 1)
-        diagnostics.push({
-          message,
-          lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColumnNumber(statement, macroNameDefinition),
-          endColumnNumber:
-            getColumnNumber(statement, macroNameDefinition) +
-            macroNameDefinition.length -
-            1,
-          severity: Severity.Warning
-        })
-      else if (macroName !== macroName.trim())
-        diagnostics.push({
-          message: 'Macro definition contains space(s)',
-          lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColumnNumber(statement, macroNameDefinition),
-          endColumnNumber:
-            getColumnNumber(statement, macroNameDefinition) +
-            macroNameDefinition.length -
-            1,
-          severity: Severity.Warning
-        })
-    }
+        const macroNameDefinitionParts = macroNameDefinition.split('(')
+        const macroName = macroNameDefinitionParts[0]
+
+        if (!macroName)
+          diagnostics.push({
+            message: 'Macro definition contains space(s)',
+            lineNumber: getLineNumber(lines, index + 1),
+            startColumnNumber: getColumnNumber(line, '%macro'),
+            endColumnNumber:
+              getColumnNumber(line, '%macro') + trimmedStatement.length,
+            severity: Severity.Warning
+          })
+        else if (macroNameDefinitionParts.length === 1)
+          diagnostics.push({
+            message,
+            lineNumber: getLineNumber(lines, index + 1),
+            startColumnNumber: getColumnNumber(line, macroNameDefinition),
+            endColumnNumber:
+              getColumnNumber(line, macroNameDefinition) +
+              macroNameDefinition.length -
+              1,
+            severity: Severity.Warning
+          })
+        else if (macroName !== macroName.trim())
+          diagnostics.push({
+            message: 'Macro definition contains space(s)',
+            lineNumber: getLineNumber(lines, index + 1),
+            startColumnNumber: getColumnNumber(line, macroNameDefinition),
+            endColumnNumber:
+              getColumnNumber(line, macroNameDefinition) +
+              macroNameDefinition.length -
+              1,
+            severity: Severity.Warning
+          })
+      }
+    })
   })
   return diagnostics
 }

--- a/src/rules/hasMacroParentheses.ts
+++ b/src/rules/hasMacroParentheses.ts
@@ -6,7 +6,7 @@ import { trimComments } from '../utils/trimComments'
 import { getColumnNumber } from '../utils/getColumnNumber'
 
 const name = 'hasMacroParentheses'
-const description = 'Enforces the presence of parantheses in macro definitions.'
+const description = 'Enforces the presence of parentheses in macro definitions.'
 const message = 'Macro definition missing parentheses'
 const test = (value: string) => {
   const diagnostics: Diagnostic[] = []
@@ -74,7 +74,7 @@ const test = (value: string) => {
 }
 
 /**
- * Lint rule that enforces the presence of parantheses in macro definitions..
+ * Lint rule that enforces the presence of parentheses in macro definitions..
  */
 export const hasMacroParentheses: FileLintRule = {
   type: LintRuleType.File,

--- a/src/rules/hasMacroParentheses.ts
+++ b/src/rules/hasMacroParentheses.ts
@@ -38,7 +38,7 @@ const test = (value: string) => {
 
         if (!macroName)
           diagnostics.push({
-            message: 'Macro definition contains space(s)',
+            message: 'Macro definition missing name',
             lineNumber: lineIndex + 1,
             startColumnNumber: getColumnNumber(line, '%macro'),
             endColumnNumber:

--- a/src/rules/hasMacroParentheses.ts
+++ b/src/rules/hasMacroParentheses.ts
@@ -4,23 +4,23 @@ import { LintRuleType } from '../types/LintRuleType'
 import { Severity } from '../types/Severity'
 import { trimComments } from '../utils/trimComments'
 import { getLineNumber } from '../utils/getLineNumber'
-import { getColNumber } from '../utils/getColNumber'
+import { getColumnNumber } from '../utils/getColumnNumber'
 
 const name = 'hasMacroParentheses'
-const description = 'Macros are always defined with parentheses'
+const description = 'Enforces the presence of parantheses in macro definitions.'
 const message = 'Macro definition missing parentheses'
 const test = (value: string) => {
   const diagnostics: Diagnostic[] = []
 
   const statements: string[] = value ? value.split(';') : []
 
-  let trimmedStatement = '',
-    commentStarted = false
+  let isCommentStarted = false
   statements.forEach((statement, index) => {
-    ;({ statement: trimmedStatement, commentStarted } = trimComments(
+    const { statement: trimmedStatement, commentStarted } = trimComments(
       statement,
-      commentStarted
-    ))
+      isCommentStarted
+    )
+    isCommentStarted = commentStarted
 
     if (trimmedStatement.startsWith('%macro')) {
       const macroNameDefinition = trimmedStatement
@@ -34,7 +34,7 @@ const test = (value: string) => {
         diagnostics.push({
           message: 'Macro definition missing name',
           lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColNumber(statement, '%macro'),
+          startColumnNumber: getColumnNumber(statement, '%macro'),
           endColumnNumber: statement.length,
           severity: Severity.Warning
         })
@@ -42,20 +42,20 @@ const test = (value: string) => {
         diagnostics.push({
           message,
           lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColNumber(statement, macroNameDefinition),
+          startColumnNumber: getColumnNumber(statement, macroNameDefinition),
           endColumnNumber:
-            getColNumber(statement, macroNameDefinition) +
+            getColumnNumber(statement, macroNameDefinition) +
             macroNameDefinition.length -
             1,
           severity: Severity.Warning
         })
       else if (macroName !== macroName.trim())
         diagnostics.push({
-          message: 'Macro definition cannot have space',
+          message: 'Macro definition contains space(s)',
           lineNumber: getLineNumber(statements, index + 1),
-          startColumnNumber: getColNumber(statement, macroNameDefinition),
+          startColumnNumber: getColumnNumber(statement, macroNameDefinition),
           endColumnNumber:
-            getColNumber(statement, macroNameDefinition) +
+            getColumnNumber(statement, macroNameDefinition) +
             macroNameDefinition.length -
             1,
           severity: Severity.Warning
@@ -66,7 +66,7 @@ const test = (value: string) => {
 }
 
 /**
- * Lint rule that checks for the presence of macro name in %mend statement.
+ * Lint rule that enforces the presence of parantheses in macro definitions..
  */
 export const hasMacroParentheses: FileLintRule = {
   type: LintRuleType.File,

--- a/src/rules/hasMacroParentheses.ts
+++ b/src/rules/hasMacroParentheses.ts
@@ -3,7 +3,6 @@ import { FileLintRule } from '../types/LintRule'
 import { LintRuleType } from '../types/LintRuleType'
 import { Severity } from '../types/Severity'
 import { trimComments } from '../utils/trimComments'
-import { getLineNumber } from '../utils/getLineNumber'
 import { getColumnNumber } from '../utils/getColumnNumber'
 
 const name = 'hasMacroParentheses'
@@ -14,7 +13,7 @@ const test = (value: string) => {
 
   const lines: string[] = value ? value.split('\n') : []
   let isCommentStarted = false
-  lines.forEach((line, index) => {
+  lines.forEach((line, lineIndex) => {
     const { statement: trimmedLine, commentStarted } = trimComments(
       line,
       isCommentStarted
@@ -40,7 +39,7 @@ const test = (value: string) => {
         if (!macroName)
           diagnostics.push({
             message: 'Macro definition contains space(s)',
-            lineNumber: getLineNumber(lines, index + 1),
+            lineNumber: lineIndex + 1,
             startColumnNumber: getColumnNumber(line, '%macro'),
             endColumnNumber:
               getColumnNumber(line, '%macro') + trimmedStatement.length,
@@ -49,7 +48,7 @@ const test = (value: string) => {
         else if (macroNameDefinitionParts.length === 1)
           diagnostics.push({
             message,
-            lineNumber: getLineNumber(lines, index + 1),
+            lineNumber: lineIndex + 1,
             startColumnNumber: getColumnNumber(line, macroNameDefinition),
             endColumnNumber:
               getColumnNumber(line, macroNameDefinition) +
@@ -60,7 +59,7 @@ const test = (value: string) => {
         else if (macroName !== macroName.trim())
           diagnostics.push({
             message: 'Macro definition contains space(s)',
-            lineNumber: getLineNumber(lines, index + 1),
+            lineNumber: lineIndex + 1,
             startColumnNumber: getColumnNumber(line, macroNameDefinition),
             endColumnNumber:
               getColumnNumber(line, macroNameDefinition) +

--- a/src/rules/noNestedMacros.spec.ts
+++ b/src/rules/noNestedMacros.spec.ts
@@ -11,7 +11,7 @@ describe('noNestedMacros', () => {
     expect(noNestedMacros.test(content)).toEqual([])
   })
 
-  it('should return an array with a single diagnostics when nested macro defined', () => {
+  it('should return an array with a single diagnostic when a macro contains a nested macro definition', () => {
     const content = `
     %macro outer();
       /* any amount of arbitrary code */
@@ -26,7 +26,7 @@ describe('noNestedMacros', () => {
 
     expect(noNestedMacros.test(content)).toEqual([
       {
-        message: "Macro definition present inside another macro 'outer'",
+        message: "Macro definition for 'inner' present in macro 'outer'",
         lineNumber: 4,
         startColumnNumber: 7,
         endColumnNumber: 20,
@@ -35,7 +35,7 @@ describe('noNestedMacros', () => {
     ])
   })
 
-  it('should return an array with a single diagnostics when nested macro defined 2 levels', () => {
+  it('should return an array with a single diagnostic when nested macros are defined at 2 levels', () => {
     const content = `
     %macro outer();
       /* any amount of arbitrary code */
@@ -54,14 +54,14 @@ describe('noNestedMacros', () => {
 
     expect(noNestedMacros.test(content)).toEqual([
       {
-        message: "Macro definition present inside another macro 'outer'",
+        message: "Macro definition for 'inner' present in macro 'outer'",
         lineNumber: 4,
         startColumnNumber: 7,
         endColumnNumber: 20,
         severity: Severity.Warning
       },
       {
-        message: "Macro definition present inside another macro 'inner'",
+        message: "Macro definition for 'inner2' present in macro 'inner'",
         lineNumber: 7,
         startColumnNumber: 17,
         endColumnNumber: 31,

--- a/src/rules/noNestedMacros.ts
+++ b/src/rules/noNestedMacros.ts
@@ -3,7 +3,6 @@ import { FileLintRule } from '../types/LintRule'
 import { LintRuleType } from '../types/LintRuleType'
 import { Severity } from '../types/Severity'
 import { trimComments } from '../utils/trimComments'
-import { getLineNumber } from '../utils/getLineNumber'
 import { getColumnNumber } from '../utils/getColumnNumber'
 
 const name = 'noNestedMacros'
@@ -15,7 +14,7 @@ const test = (value: string) => {
 
   const lines: string[] = value ? value.split('\n') : []
   let isCommentStarted = false
-  lines.forEach((line, index) => {
+  lines.forEach((line, lineIndex) => {
     const { statement: trimmedLine, commentStarted } = trimComments(
       line,
       isCommentStarted
@@ -41,7 +40,7 @@ const test = (value: string) => {
             message: message
               .replace('{macro}', macroName)
               .replace('{parent}', parentMacro!),
-            lineNumber: getLineNumber(lines, index + 1),
+            lineNumber: lineIndex + 1,
             startColumnNumber: getColumnNumber(line, '%macro'),
             endColumnNumber:
               getColumnNumber(line, '%macro') + trimmedStatement.length - 1,

--- a/src/utils/asyncForEach.ts
+++ b/src/utils/asyncForEach.ts
@@ -1,3 +1,6 @@
+/**
+ * Executes an async callback for each item in the given array.
+ */
 export async function asyncForEach(
   array: any[],
   callback: (item: any, index: number, originalArray: any[]) => any

--- a/src/utils/getColNumber.ts
+++ b/src/utils/getColNumber.ts
@@ -1,3 +1,0 @@
-export const getColNumber = (statement: string, text: string): number => {
-  return (statement.split('\n').pop() as string).indexOf(text) + 1
-}

--- a/src/utils/getColumnNumber.spec.ts
+++ b/src/utils/getColumnNumber.spec.ts
@@ -1,0 +1,13 @@
+import { getColumnNumber } from './getColumnNumber'
+
+describe('getColumnNumber', () => {
+  it('should return the column number of the specified string within a line of text', () => {
+    expect(getColumnNumber('foo bar', 'bar')).toEqual(5)
+  })
+
+  it('should throw an error when the specified string is not found within the text', () => {
+    expect(() => getColumnNumber('foo bar', 'baz')).toThrowError(
+      "String 'baz' was not found in statement 'foo bar'"
+    )
+  })
+})

--- a/src/utils/getColumnNumber.spec.ts
+++ b/src/utils/getColumnNumber.spec.ts
@@ -7,7 +7,7 @@ describe('getColumnNumber', () => {
 
   it('should throw an error when the specified string is not found within the text', () => {
     expect(() => getColumnNumber('foo bar', 'baz')).toThrowError(
-      "String 'baz' was not found in statement 'foo bar'"
+      "String 'baz' was not found in line 'foo bar'"
     )
   })
 })

--- a/src/utils/getColumnNumber.ts
+++ b/src/utils/getColumnNumber.ts
@@ -1,0 +1,9 @@
+export const getColumnNumber = (statement: string, text: string): number => {
+  const index = (statement.split('\n').pop() as string).indexOf(text)
+  if (index < 0) {
+    throw new Error(
+      `String '${text}' was not found in statement '${statement}'`
+    )
+  }
+  return (statement.split('\n').pop() as string).indexOf(text) + 1
+}

--- a/src/utils/getColumnNumber.ts
+++ b/src/utils/getColumnNumber.ts
@@ -1,9 +1,7 @@
-export const getColumnNumber = (statement: string, text: string): number => {
-  const index = (statement.split('\n').pop() as string).indexOf(text)
+export const getColumnNumber = (line: string, text: string): number => {
+  const index = (line.split('\n').pop() as string).indexOf(text)
   if (index < 0) {
-    throw new Error(
-      `String '${text}' was not found in statement '${statement}'`
-    )
+    throw new Error(`String '${text}' was not found in line '${line}'`)
   }
-  return (statement.split('\n').pop() as string).indexOf(text) + 1
+  return (line.split('\n').pop() as string).indexOf(text) + 1
 }

--- a/src/utils/getLineNumber.ts
+++ b/src/utils/getLineNumber.ts
@@ -1,5 +1,4 @@
-export const getLineNumber = (statements: string[], index: number): number => {
-  const combinedCode = statements.slice(0, index).join(';')
-  const lines = (combinedCode.match(/\n/g) || []).length + 1
-  return lines
+export const getLineNumber = (lines: string[], index: number): number => {
+  const combinedCode = lines.slice(0, index).join('\n')
+  return (combinedCode.match(/\n/g) || []).length + 1
 }

--- a/src/utils/getLineNumber.ts
+++ b/src/utils/getLineNumber.ts
@@ -1,4 +1,0 @@
-export const getLineNumber = (lines: string[], index: number): number => {
-  const combinedCode = lines.slice(0, index).join('\n')
-  return (combinedCode.match(/\n/g) || []).length + 1
-}

--- a/src/utils/listSasFiles.ts
+++ b/src/utils/listSasFiles.ts
@@ -1,5 +1,9 @@
 import { listFilesInFolder } from '@sasjs/utils/file'
 
+/**
+ * Fetches a list of .sas files in the given path.
+ * @returns {Promise<string[]>} resolves with an array of file names.
+ */
 export const listSasFiles = async (folderPath: string): Promise<string[]> => {
   const files = await listFilesInFolder(folderPath)
   return files.filter((f) => f.endsWith('.sas'))

--- a/src/utils/trimComments.spec.ts
+++ b/src/utils/trimComments.spec.ts
@@ -1,0 +1,74 @@
+import { trimComments } from './trimComments'
+
+describe('trimComments', () => {
+  it('should return statment', () => {
+    expect(
+      trimComments(`
+      /* some comment */ some code;
+      `)
+    ).toEqual({ statement: 'some code;', commentStarted: false })
+  })
+
+  it('should return statment, having multi-line comment', () => {
+    expect(
+      trimComments(`
+        /* some 
+        comment */
+      some code;
+      `)
+    ).toEqual({ statement: 'some code;', commentStarted: false })
+  })
+
+  it('should return statment, having multi-line comment and some code present in comment', () => {
+    expect(
+      trimComments(`
+        /* some 
+      some code;
+        comment */
+      some other code;
+      `)
+    ).toEqual({ statement: 'some other code;', commentStarted: false })
+  })
+
+  it('should return empty statment, having only comment', () => {
+    expect(
+      trimComments(`
+        /* some 
+      some code;
+        comment */
+      `)
+    ).toEqual({ statement: '', commentStarted: false })
+  })
+
+  it('should return empty statment, having continuity in comment', () => {
+    expect(
+      trimComments(`
+        /* some 
+      some code;
+      `)
+    ).toEqual({ statement: '', commentStarted: true })
+  })
+
+  it('should return statment, having already started comment and ends', () => {
+    expect(
+      trimComments(
+        `
+        comment */
+      some code;
+      `,
+        true
+      )
+    ).toEqual({ statement: 'some code;', commentStarted: false })
+  })
+
+  it('should return empty statment, having already started comment and continuity in comment', () => {
+    expect(
+      trimComments(
+        `
+      some code;
+      `,
+        true
+      )
+    ).toEqual({ statement: '', commentStarted: true })
+  })
+})

--- a/src/utils/trimComments.ts
+++ b/src/utils/trimComments.ts
@@ -2,7 +2,7 @@ export const trimComments = (
   statement: string,
   commentStarted: boolean = false
 ): { statement: string; commentStarted: boolean } => {
-  let trimmed = statement.trim()
+  let trimmed = (statement || '').trim()
 
   if (commentStarted || trimmed.startsWith('/*')) {
     const parts = trimmed.split('*/')


### PR DESCRIPTION
## Issue

No linked issues.

## Intent

* Improve code and make more readable - variable names, rule descriptions and warning messages.
* Add test cases for scenarios that were not tested.
* Fix copy-paste comments that were not updated.
* Update `.sasjslint` schema definition with new rules.

## Implementation

* Updated `sasjslint-schema.json`.
* Improved message for `hasMacroNameInMend` rule, added test cases for when a macro is entirely missing a `%mend` statement, generate one diagnostic for each macro missing `%mend`.
* Added test case for macro definition with spaces in `hasMacroParentheses`.
* Added macro names for inner and outer macros in `noNestedMacros` warning message, updated test cases.
* Added comments for some exported functions that were missing them.
* Added spec for `getColumnNumber` util function.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
