### PR TITLE
fix: doxygen header enforces double asterisks

### DIFF
--- a/src/rules/file/hasDoxygenHeader.spec.ts
+++ b/src/rules/file/hasDoxygenHeader.spec.ts
@@ -128,7 +128,7 @@ describe('hasDoxygenHeader - fix', () => {
     /**
    @file
    @brief Returns an unused libref
- **/
+ */
 
  %macro mf_getuniquelibref(prefix=mclib,maxtries=1000);
    %local x libref;

--- a/src/rules/file/hasDoxygenHeader.ts
+++ b/src/rules/file/hasDoxygenHeader.ts
@@ -10,10 +10,28 @@ const name = 'hasDoxygenHeader'
 const description =
   'Enforce the presence of a Doxygen header at the start of each file.'
 const message = 'File missing Doxygen header'
-const test = (value: string) => {
+const messageForSingleAsterisk =
+  'File not following Doxygen header style, use double asterisks'
+const test = (value: string, config?: LintConfig) => {
+  const lineEnding = config?.lineEndings === LineEndings.CRLF ? '\r\n' : '\n'
   try {
-    const hasFileHeader = value.trimStart().startsWith('/*')
+    const hasFileHeader = value.trimStart().startsWith('/**')
     if (hasFileHeader) return []
+
+    const hasFileHeaderWithSingleAsterisk = value.trimStart().startsWith('/*')
+    if (hasFileHeaderWithSingleAsterisk)
+      return [
+        {
+          message: messageForSingleAsterisk,
+          lineNumber:
+            (value.split('/*')![0]!.match(new RegExp(lineEnding, 'g')) ?? [])
+              .length + 1,
+          startColumnNumber: 1,
+          endColumnNumber: 1,
+          severity: Severity.Warning
+        }
+      ]
+
     return [
       {
         message,
@@ -37,9 +55,12 @@ const test = (value: string) => {
 }
 
 const fix = (value: string, config?: LintConfig): string => {
-  if (test(value).length === 0) {
+  const result = test(value, config)
+  if (result.length === 0) {
     return value
-  }
+  } else if (result[0].message == messageForSingleAsterisk)
+    return value.replace('/*', '/**').replace('*/', '**/')
+
   const lineEndingConfig = config?.lineEndings || LineEndings.LF
   const lineEnding = lineEndingConfig === LineEndings.LF ? '\n' : '\r\n'
 

--- a/src/rules/file/hasDoxygenHeader.ts
+++ b/src/rules/file/hasDoxygenHeader.ts
@@ -59,7 +59,7 @@ const fix = (value: string, config?: LintConfig): string => {
   if (result.length === 0) {
     return value
   } else if (result[0].message == messageForSingleAsterisk)
-    return value.replace('/*', '/**').replace('*/', '**/')
+    return value.replace('/*', '/**')
 
   const lineEndingConfig = config?.lineEndings || LineEndings.LF
   const lineEnding = lineEndingConfig === LineEndings.LF ? '\n' : '\r\n'


### PR DESCRIPTION
## Issue

CLI issue: https://github.com/sasjs/cli/issues/757

## Intent

Update rule `hasDoxygenHeader` test & fix. 

## Implementation

Updated rule `hasDoxygenHeader`
- added new message for using single asterisk


## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] sasjslint-schema.json is updated with any new / changed functionality
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
