### PR TITLE
fix: postinstall -> prepare, support windows CMD/Powershell

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "package:lib": "npm run build && cp ./package.json build && cp README.md build && cd build && npm version \"5.0.0\" && npm pack",
     "lint:fix": "npx prettier --write '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
     "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
-    "postinstall": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true"
+    "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Intent

Command specified in `postinstall` is not supported in windows CMD
Also move it to `prepare` instead of `postinstall`

## Implementation

Changed posinstall command from `[ -d .git ] && ...` to `git rev-parse --git-dir && ...`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] sasjslint-schema.json is updated with any new / changed functionality
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
