### PR TITLE
feat: customise the defaultHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,32 @@ Configuration is via a `.sasjslint` file with the following structure (these are
     "noNestedMacros": true,
     "noSpacesInFileNames": true,
     "noTabIndentation": true,
-    "noTrailingSpaces": true
+    "noTrailingSpaces": true,
+    "defaultHeader": "/**{lineEnding}  @file{lineEnding}  @brief <Your brief here>{lineEnding}  <h4> SAS Macros </h4>{lineEnding}**/"
 }
 ```
 
 ### SAS Lint Settings
+
+#### defaultHeader
+
+This sets the default program header - applies when a SAS program does NOT begin with `/**`.  The default header is as follows:
+
+```sas
+/**
+  @file
+  @brief <Your brief here>
+  <h4> SAS Macros </h4>
+**/
+```
+
+The default header is automatically applied when running `sasjs lint fix` in the SASjs CLI, or by hitting "save" when using the SASjs VS Code extension.  If creating a new value, use `{lineEnding}` instead of `\n`, eg as follows:
+
+```json
+{
+  "defaultHeader": "/**{lineEnding}  @file{lineEnding}  @brief Our Company Brief{lineEnding}**/"
+}
+```
 
 #### noEncodedPasswords
 
@@ -82,7 +103,7 @@ On *nix systems, it is imperative that autocall macros are in lowercase.  When s
 #### maxLineLength
 Code becomes far more readable when line lengths are short.  The most compelling reason for short line lengths is to avoid the need to scroll when performing a side-by-side 'compare' between two files (eg as part of a GIT feature branch review).  A longer discussion on optimal code line length can be found [here](https://stackoverflow.com/questions/578059/studies-on-optimal-code-width)
 
-In batch mode, long SAS code lines may also be truncated, causing hard-to-detect errors.  
+In batch mode, long SAS code lines may also be truncated, causing hard-to-detect errors.
 
 We strongly recommend a line length limit, and set the bar at 80.  To turn this feature off, set the value to 0.
 
@@ -90,7 +111,7 @@ We strongly recommend a line length limit, and set the bar at 80.  To turn this 
 * Severity: WARNING
 
 #### noNestedMacros
-Where macros are defined inside other macros, they are recompiled every time the outer macro is invoked.  Hence, it is widely considered inefficient, and bad practice, to nest macro definitions.  
+Where macros are defined inside other macros, they are recompiled every time the outer macro is invoked.  Hence, it is widely considered inefficient, and bad practice, to nest macro definitions.
 
 * Default:  true
 * Severity: WARNING
@@ -120,7 +141,7 @@ This will highlight lines with trailing spaces.  Trailing spaces serve no useful
 
 ### Upcoming Linting Rules:
 
-* `noTabs` -> does what it says on the tin 
+* `noTabs` -> does what it says on the tin
 * `noGremlins` -> identifies all invisible characters, other than spaces / tabs / line endings.  If you really need that bell character, use a hex literal!
 * `lineEndings` -> set a standard line ending, such as LF or CRLF
 
@@ -130,13 +151,13 @@ A formatter will automatically apply rules when you hit SAVE, which can save a L
 
 We've already implemented the following rules:
 
-* Add the macro name to the %mend statement 
-* Add a doxygen header template if none exists 
+* Add the macro name to the %mend statement
+* Add a doxygen header template if none exists
 * Remove trailing spaces
 
 We're looking to implement the following rules:
 
-* Change tabs to spaces 
+* Change tabs to spaces
 * zap gremlins
 * fix line endings
 

--- a/src/format/shared.ts
+++ b/src/format/shared.ts
@@ -19,7 +19,7 @@ const processContent = (config: LintConfig, content: string): string => {
   config.fileLintRules
     .filter((r) => !!r.fix)
     .forEach((rule) => {
-      processedContent = rule.fix!(processedContent)
+      processedContent = rule.fix!(processedContent, config)
     })
 
   return processedContent

--- a/src/rules/file/hasDoxygenHeader.ts
+++ b/src/rules/file/hasDoxygenHeader.ts
@@ -3,8 +3,7 @@ import { LineEndings } from '../../types/LineEndings'
 import { FileLintRule } from '../../types/LintRule'
 import { LintRuleType } from '../../types/LintRuleType'
 import { Severity } from '../../types/Severity'
-
-const DoxygenHeader = `/**{lineEnding}  @file{lineEnding}  @brief <Your brief here>{lineEnding}  <h4> SAS Macros </h4>{lineEnding}**/`
+import { DefaultLintConfiguration } from '../../utils/getLintConfig'
 
 const name = 'hasDoxygenHeader'
 const description =
@@ -61,10 +60,11 @@ const fix = (value: string, config?: LintConfig): string => {
   } else if (result[0].message == messageForSingleAsterisk)
     return value.replace('/*', '/**')
 
+  config = config || new LintConfig(DefaultLintConfiguration)
   const lineEndingConfig = config?.lineEndings || LineEndings.LF
   const lineEnding = lineEndingConfig === LineEndings.LF ? '\n' : '\r\n'
 
-  return `${DoxygenHeader.replace(
+  return `${config?.defaultHeader.replace(
     /{lineEnding}/g,
     lineEnding
   )}${lineEnding}${value}`

--- a/src/types/LintConfig.ts
+++ b/src/types/LintConfig.ts
@@ -16,6 +16,7 @@ import {
 import { lowerCaseFileNames, noSpacesInFileNames } from '../rules/path'
 import { LineEndings } from './LineEndings'
 import { FileLintRule, LineLintRule, PathLintRule } from './LintRule'
+import { getDefaultHeader } from '../utils'
 
 /**
  * LintConfig is the logical representation of the .sasjslint file.
@@ -32,6 +33,7 @@ export class LintConfig {
   readonly maxLineLength: number = 80
   readonly indentationMultiple: number = 2
   readonly lineEndings: LineEndings = LineEndings.LF
+  readonly defaultHeader: string = getDefaultHeader()
 
   constructor(json?: any) {
     if (json?.ignoreList) {
@@ -85,6 +87,10 @@ export class LintConfig {
 
     if (json?.hasDoxygenHeader) {
       this.fileLintRules.push(hasDoxygenHeader)
+    }
+
+    if (json?.defaultHeader) {
+      this.defaultHeader = json.defaultHeader
     }
 
     if (json?.noSpacesInFileNames) {

--- a/src/utils/getLintConfig.ts
+++ b/src/utils/getLintConfig.ts
@@ -3,6 +3,9 @@ import { LintConfig } from '../types/LintConfig'
 import { readFile } from '@sasjs/utils/file'
 import { getProjectRoot } from './getProjectRoot'
 
+export const getDefaultHeader = () =>
+  `/**{lineEnding}  @file{lineEnding}  @brief <Your brief here>{lineEnding}  <h4> SAS Macros </h4>{lineEnding}**/`
+
 /**
  * Default configuration that is used when a .sasjslint file is not found
  */
@@ -18,7 +21,8 @@ export const DefaultLintConfiguration = {
   hasMacroNameInMend: true,
   noNestedMacros: true,
   hasMacroParentheses: true,
-  strictMacroDefinition: true
+  strictMacroDefinition: true,
+  defaultHeader: getDefaultHeader()
 }
 
 /**


### PR DESCRIPTION
## Issue

closes #178

## Intent

* a new attribute (defaultHeader) in the .sasjslint file. If not provided, the default value will be `/**{lineEnding}  @file{lineEnding}  @brief <Your brief here>{lineEnding}  <h4> SAS Macros </h4>{lineEnding}**/`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] sasjslint-schema.json is updated with any new / changed functionality
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
