### PR TITLE
fix: lineEndings should be off by default

### DIFF
--- a/sasjslint-schema.json
+++ b/sasjslint-schema.json
@@ -20,7 +20,7 @@
     "noSpacesInFileNames": true,
     "noTabs": true,
     "noTrailingSpaces": true,
-    "lineEndings": "lf",
+    "lineEndings": "off",
     "strictMacroDefinition": true,
     "ignoreList": ["sajsbuild", "sasjsresults"]
   },
@@ -185,7 +185,7 @@
       "enum": ["lf", "crlf", "off"],
       "title": "lineEndings",
       "description": "Enforces the configured terminating character for each line. Shows a warning when incorrect line endings are present.",
-      "default": "lf",
+      "default": "off",
       "examples": ["lf", "crlf"]
     },
     "strictMacroDefinition": {

--- a/src/utils/getLintConfig.ts
+++ b/src/utils/getLintConfig.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { LintConfig } from '../types/LintConfig'
 import { readFile } from '@sasjs/utils/file'
 import { getProjectRoot } from './getProjectRoot'
+import { LineEndings } from '../types/LineEndings'
 
 export const getDefaultHeader = () =>
   `/**{lineEnding}  @file{lineEnding}  @brief <Your brief here>{lineEnding}  <h4> SAS Macros </h4>{lineEnding}**/`
@@ -10,6 +11,7 @@ export const getDefaultHeader = () =>
  * Default configuration that is used when a .sasjslint file is not found
  */
 export const DefaultLintConfiguration = {
+  lineEndings: LineEndings.OFF,
   noTrailingSpaces: true,
   noEncodedPasswords: true,
   hasDoxygenHeader: true,


### PR DESCRIPTION
## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] sasjslint-schema.json is updated with any new / changed functionality
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
