### PR TITLE
Add clarification about SASjs and SAS Institute

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Our goal is to help SAS developers everywhere spend less time on code reviews, bug fixing and arguing about standards - and more time delivering extraordinary business value.
 
+*Note:* The SASjs project and its repositories are not affiliated with SAS Institute.
+
 # Linting
 
 @sasjs/lint is used by the following products:


### PR DESCRIPTION
## Issue

Add clarification that this SASjs project is not affiliated with SAS Institute.

## Intent

Simply prevent confusion about SAS involvement.

## Implementation

Simple doc change


